### PR TITLE
fix: Show inventory item details

### DIFF
--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -17,10 +17,15 @@ export const ActionButtons = () => {
   const [openInventoryDialog, setOpenInventoryDialog] = useState(false); // New state for inventory dialog
   const [openRecallDialog, setOpenRecallDialog] = useState(false); // New state for recall dialog
   const [serverResponse, setServerResponse] = useState<ServerResponse>();
-  const { sendJsonMessage } = useWebSocket(getSocketURL(), {
+  const { sendJsonMessage } = useWebSocket<ServerResponse>(getSocketURL(), {
     share: true,
     filter(message: WebSocketEventMap['message']) {
       const serverResponse = JSON.parse(message.data) as ServerResponse;
+
+      // TODO: setServerResponse needs to be removed from here
+      // We should not be setting the state in the filter function
+      // the filter function should only return true or false indicating whether this component is intersted in that type or not
+      // and useEffect should be used to assign values to state according to the type of the message
       setServerResponse(serverResponse);
       console.log('response', serverResponse);
       return serverResponse.type === 'exits';
@@ -67,7 +72,7 @@ export const ActionButtons = () => {
   };
 
   const handleInventoryButtonClick = () => {
-    sendCommand('inventory');
+    //sendCommand('inventory');
     setOpenInventoryDialog(true); // Open the inventory dialog
   };
   const handleCloseInventoryDialog = () => {
@@ -225,9 +230,9 @@ export const ActionButtons = () => {
           aria-labelledby="inventory-dialog-title"
         >
           <DialogTitle id="inventory-dialog-title">Inventory Information</DialogTitle>
-          {serverResponse && serverResponse.type === 'inventory' && (
-            <InventoryComponent serverResponse={serverResponse} />
-          )}
+          {/* {serverResponse && serverResponse.type === 'inventory' && ( */}
+          <InventoryComponent sendCommand={sendCommand} />
+          {/* )} */}
         </Dialog>
         {/* Dialog for Recall */}
         <Dialog open={openRecallDialog} onClose={handleCloseRecallDialog} aria-labelledby="recall-dialog-title">

--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -1,4 +1,5 @@
-import { Button, Dialog, DialogTitle, Grid } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { AppBar, Button, Dialog, DialogTitle, Grid, IconButton, Toolbar } from '@mui/material';
 import React, { useState } from 'react';
 import useWebSocket from 'react-use-websocket';
 
@@ -225,11 +226,21 @@ export const ActionButtons = () => {
         </Dialog>
         {/* Dialog for Inventory */}
         <Dialog
+          fullScreen
           open={openInventoryDialog}
           onClose={handleCloseInventoryDialog}
           aria-labelledby="inventory-dialog-title"
         >
-          <DialogTitle id="inventory-dialog-title">Inventory Information</DialogTitle>
+          {' '}
+          <AppBar sx={{ position: 'relative' }}>
+            <Toolbar>
+              <IconButton edge="start" color="inherit" onClick={handleCloseInventoryDialog} aria-label="close">
+                <CloseIcon />
+              </IconButton>
+              Close Inventory
+            </Toolbar>
+          </AppBar>
+          {/* <DialogTitle id="inventory-dialog-title">Inventory Information</DialogTitle> */}
           {/* {serverResponse && serverResponse.type === 'inventory' && ( */}
           <InventoryComponent sendCommand={sendCommand} />
           {/* )} */}

--- a/src/components/Inventory.tsx
+++ b/src/components/Inventory.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup } from '@mui/material';
+import { Button, ButtonGroup, CardContent, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import useWebSocket from 'react-use-websocket';
 
@@ -6,7 +6,7 @@ import { getSocketURL } from '../config';
 import type { ClientCommand, Inventory, ItemDetails, ItemType, ServerResponse } from '../types';
 
 type InventoryProps = {
-  serverResponse: ServerResponse;
+  sendCommand: (_command: string) => void;
 };
 
 type ItemDetailsProps = {
@@ -14,43 +14,59 @@ type ItemDetailsProps = {
 };
 
 export const ItemDetailsComponent = ({ itemDetails }: ItemDetailsProps) => {
-  // No need to fetch the details or use WebSocket in this component now
-  // Just render the details using the itemDetails prop
+  if (itemDetails === null) {
+    return <React.Fragment></React.Fragment>;
+  }
 
-  console.log(`ItemDetails: ${itemDetails}`);
-
-  return <React.Fragment></React.Fragment>;
+  return (
+    <React.Fragment>
+      <CardContent>
+        <Typography sx={{ fontSize: 14 }} color="text.secondary" gutterBottom>
+          {itemDetails.itemID}
+        </Typography>
+        <Typography variant="h5" component="div">
+          {itemDetails.name}
+        </Typography>
+        <Typography sx={{ mb: 1.5 }} color="text.secondary">
+          {itemDetails.description}
+        </Typography>
+        <Typography variant="body2">{itemDetails.type}</Typography>
+      </CardContent>
+    </React.Fragment>
+  );
 };
 
-export const InventoryComponent = (props: InventoryProps) => {
-  // This should be the state for storing the details of a single item
-  const [itemDetails, setItemDetails] = useState<ItemDetails | null>(null);
-
-  const [inventory, setInventory] = useState<Inventory | null>(null);
-
-  // type ItemDetailsProps = {
-  //   itemDetails: ItemDetails;
-  //   // sendJsonMessage is probably not needed anymore if you're passing the details directly
-  // };
-
-  const inventoryMessage = props.serverResponse.message;
-  //const [openLookDialog, setOpenLookDialog] = useState(false);
-  // const [activeItemId, setActiveItemId] = useState<number | null>(null);
-
-  try {
-    let data: Inventory | null = null;
-    data = JSON.parse(inventoryMessage) as Inventory;
-    setInventory(data);
-  } catch (err) {
-    console.error('Error parsing inventory:', err);
-  }
+export const InventoryComponent = ({ sendCommand }: InventoryProps) => {
   const { sendJsonMessage, lastJsonMessage } = useWebSocket<ServerResponse>(getSocketURL(), {
     share: true,
     filter(message: WebSocketEventMap['message']) {
       const serverResponse = JSON.parse(message.data) as ServerResponse;
-      return serverResponse.type === 'itemDetails';
+      return serverResponse.type === 'inventory' || serverResponse.type === 'itemDetails';
     },
   });
+
+  // Disable the eslint warning for the dependency array here as we only want to run this once
+  // when the component is first mounted so dependencies need to be empty array []
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => sendCommand('inventory'), []);
+
+  // This should be the state for storing the details of a single item
+  const [itemDetails, setItemDetails] = useState<ItemDetails | null>(null);
+  const [inventory, setInventory] = useState<Inventory>({} as Inventory);
+
+  // Expandable Sections: If the secondary dialog contains additional information or options related to a selection in the primary dialog, consider using expandable sections or accordions within the dialog. This allows the user to see more information without leaving the context of the original dialog.
+
+  useEffect(() => {
+    if (lastJsonMessage !== null) {
+      if (lastJsonMessage.type === 'inventory') {
+        const data = JSON.parse(lastJsonMessage.message) as Inventory;
+        setInventory(data); // Now you're setting the state correctly
+      } else if (lastJsonMessage.type === 'itemDetails') {
+        const response = lastJsonMessage as unknown as ItemDetails; // Use type assertion
+        setItemDetails(response); // Now you're setting the state correctly
+      }
+    }
+  }, [lastJsonMessage]);
 
   const handleDrop = (item: ItemType) => {
     const messageForServer: ClientCommand = {
@@ -68,36 +84,15 @@ export const InventoryComponent = (props: InventoryProps) => {
     sendJsonMessage(messageForServer);
   };
 
-  // const handleLook = (item: ItemType) => {
-  //   const messageForServer: ClientCommand = {
-  //     type: 'command',
-  //     command: `ilook ${item.itemInstanceID}`,
-  //   };
-  //   sendJsonMessage(messageForServer);
-  // };
-
   const handleLook = (itemId: number) => {
-    // setActiveItemId(itemId); // Set the active item ID
-    // setOpenLookDialog(true); // Open the dialog
     // Send the command to the server
+    console.log(`Looking at item ${itemId}`);
     const messageForServer: ClientCommand = {
       type: 'command',
       command: `ilook ${itemId}`,
     };
     sendJsonMessage(messageForServer);
   };
-
-  // Expandable Sections: If the secondary dialog contains additional information or options related to a selection in the primary dialog, consider using expandable sections or accordions within the dialog. This allows the user to see more information without leaving the context of the original dialog.
-
-  useEffect(() => {
-    if (lastJsonMessage !== null) {
-      const response = lastJsonMessage as unknown as ItemDetails; // Use type assertion
-      if (response.type === 'itemDetails') {
-        //setOpenLookDialog(true); // Open the dialog after setting the details
-        setItemDetails(response); // Now you're setting the state correctly
-      }
-    }
-  }, [lastJsonMessage]);
 
   return (
     <React.Fragment>

--- a/src/components/Inventory.tsx
+++ b/src/components/Inventory.tsx
@@ -1,13 +1,10 @@
-import { Button, ButtonGroup, CardContent, Typography } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { AppBar, Button, ButtonGroup, CardContent, IconButton, Toolbar, Typography } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import useWebSocket from 'react-use-websocket';
 
 import { getSocketURL } from '../config';
 import type { ClientCommand, Inventory, ItemDetails, ItemType, ServerResponse } from '../types';
-
-type InventoryProps = {
-  sendCommand: (_command: string) => void;
-};
 
 type ItemDetailsProps = {
   itemDetails: ItemDetails | null;
@@ -36,6 +33,10 @@ export const ItemDetailsComponent = ({ itemDetails }: ItemDetailsProps) => {
   );
 };
 
+type InventoryProps = {
+  sendCommand: (_command: string) => void;
+};
+
 export const InventoryComponent = ({ sendCommand }: InventoryProps) => {
   const { sendJsonMessage, lastJsonMessage } = useWebSocket<ServerResponse>(getSocketURL(), {
     share: true,
@@ -53,6 +54,7 @@ export const InventoryComponent = ({ sendCommand }: InventoryProps) => {
   // This should be the state for storing the details of a single item
   const [itemDetails, setItemDetails] = useState<ItemDetails | null>(null);
   const [inventory, setInventory] = useState<Inventory>({} as Inventory);
+  const [showDetails, setShowDetails] = useState(false);
 
   // Expandable Sections: If the secondary dialog contains additional information or options related to a selection in the primary dialog, consider using expandable sections or accordions within the dialog. This allows the user to see more information without leaving the context of the original dialog.
 
@@ -92,8 +94,30 @@ export const InventoryComponent = ({ sendCommand }: InventoryProps) => {
       command: `ilook ${itemId}`,
     };
     sendJsonMessage(messageForServer);
+    setShowDetails(true);
   };
 
+  const handleCloseDetails = () => {
+    setShowDetails(false); // Close the inventory dialog
+  };
+
+  if (showDetails) {
+    return (
+      <React.Fragment>
+        <AppBar sx={{ position: 'relative' }}>
+          <Toolbar>
+            <IconButton edge="start" color="inherit" onClick={handleCloseDetails} aria-label="close">
+              <ArrowBackIcon />
+            </IconButton>
+            Back to list
+          </Toolbar>
+        </AppBar>
+        <ItemDetailsComponent itemDetails={itemDetails} />
+      </React.Fragment>
+    );
+  }
+
+  // by default, return the list of items in inventory
   return (
     <React.Fragment>
       {inventory && inventory.items ? (
@@ -117,10 +141,6 @@ export const InventoryComponent = ({ sendCommand }: InventoryProps) => {
       ) : (
         <div>No inventory items found.</div>
       )}
-      {/* <Dialog open={openLookDialog} onClose={() => setOpenLookDialog(false)}>
-        <DialogTitle id="look-dialog-title">Item Details</DialogTitle> */}
-      <ItemDetailsComponent itemDetails={itemDetails} />
-      {/* </Dialog> */}
     </React.Fragment>
   );
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,6 @@ export function getSocketURL() {
   // if the value is not provided, we will fall back to the current host
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const host = window.location.host;
-  console.log(`Using ${protocol}//${host}/websocket`);
+  // console.log(`Using ${protocol}//${host}/websocket`);
   return `${protocol}//${host}/websocket`;
 }


### PR DESCRIPTION
Have pushed the data retrieval to `inventory` component. 

Starts like this

![image](https://github.com/mattlawnz/gomud-client/assets/24932925/626945f7-2476-42ee-91ac-9dda16d2e221)

`Look` for first item shows like this
![image](https://github.com/mattlawnz/gomud-client/assets/24932925/212f6d96-2c35-403f-913f-83b6b8ae47d4)

`Look` for second item shows like this
![image](https://github.com/mattlawnz/gomud-client/assets/24932925/7aa98c25-f16d-4baf-b748-75da6ece2eb4)


It's working now but the problem I see is that there could be more info and mobile screens may struggle to show all. I'll see if I can change something here to change content to details and then be able to go back to previous list.